### PR TITLE
Added sub package setup for dracut modules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,3 +34,68 @@ Description: Flexible OS Image and Appliance Builder
  The KIWI Image System provides an operating system image builder
  for Linux supported hardware platforms as well as for virtualization
  and cloud systems.
+
+Package: kiwi-dracut-lib
+Architecture: any
+Depends: bc,
+         cryptsetup,
+         btrfs-progs,
+         gdisk,
+         dracut-network,
+         e2fsprogs,
+         grep,
+         lvm2,
+         mdadm,
+         parted,
+         util-linux,
+         xz-utils,
+         dmsetup,
+         dracut
+Description: KIWI - Dracut kiwi Library
+ This package contains a collection of methods to provide a library
+ for tasks done in other kiwi dracut modules
+
+Package: kiwi-dracut-oem-repart
+Architecture: any
+Depends: kiwi-dracut-lib
+Description: KIWI - Dracut module for oem(repart) image type
+ This package contains the kiwi-repart dracut module which is
+ used to repartition the oem disk image to the current disk
+ geometry according to the setup in the kiwi image configuration
+
+Package: kiwi-dracut-oem-dump
+Architecture: any
+Depends: kiwi-dracut-lib,
+         kexec-tools,
+         gawk,
+         kpartx
+Description: KIWI - Dracut module for oem(install) image type
+ This package contains the kiwi-dump and kiwi-dump-reboot dracut
+ modules which is used to install an oem image onto a target disk.
+ It implements a simple installer which allows for user selected
+ target disk or unattended installation to target. The source of
+ the image to install could be either from media(CD/DVD/USB) or
+ from remote
+
+Package: kiwi-dracut-live
+Architecture: any
+Depends: dialog,
+         xfsprogs,
+         e2fsprogs,
+         util-linux,
+         dmsetup,
+         dracut-network,
+         dracut,
+         xorriso,
+         parted
+Description: KIWI - Dracut module for iso(live) image type
+ This package contains the kiwi-live dracut module which is used
+ for booting iso(live) images built with KIWI
+
+Package: kiwi-dracut-overlay
+Architecture: any
+Depends: kiwi-dracut-lib
+Description: KIWI - Dracut module for vmx(+overlay) image type
+ This package contains the kiwi-overlay dracut module which is used
+ for booting vmx images built with KIWI and configured to use an
+ overlay root filesystem

--- a/debian/kiwi-dracut-lib.install
+++ b/debian/kiwi-dracut-lib.install
@@ -1,0 +1,1 @@
+usr/lib/dracut/modules.d/99kiwi-lib

--- a/debian/kiwi-dracut-live.install
+++ b/debian/kiwi-dracut-live.install
@@ -1,0 +1,1 @@
+usr/lib/dracut/modules.d/90kiwi-live

--- a/debian/kiwi-dracut-oem-dump.install
+++ b/debian/kiwi-dracut-oem-dump.install
@@ -1,0 +1,2 @@
+usr/lib/dracut/modules.d/90kiwi-dump
+usr/lib/dracut/modules.d/99kiwi-dump-reboot

--- a/debian/kiwi-dracut-oem-repart.install
+++ b/debian/kiwi-dracut-oem-repart.install
@@ -1,0 +1,1 @@
+usr/lib/dracut/modules.d/90kiwi-repart

--- a/debian/kiwi-dracut-overlay.install
+++ b/debian/kiwi-dracut-overlay.install
@@ -1,0 +1,1 @@
+usr/lib/dracut/modules.d/90kiwi-overlay

--- a/debian/kiwi.install
+++ b/debian/kiwi.install
@@ -1,1 +1,3 @@
+usr/bin/kiwi-ng
+usr/lib/python*/dist-packages/kiwi*
 usr/share/bash-completion/completions/kiwi-ng

--- a/debian/rules
+++ b/debian/rules
@@ -25,9 +25,9 @@ override_dh_auto_build:
 	make -C doc man
 
 override_dh_auto_install:
-	make buildroot= install
+	make buildroot= install install_dracut
 	dh_auto_install
-	rm -f debian/kiwi/usr/bin/kiwicompat
+	rm -f debian/tmp/usr/bin/kiwicompat
 
 %:
 	dh $@ --with python3,sphinxdoc --buildsystem=pybuild


### PR DESCRIPTION
Added the following sub-packages to provide the kiwi
dracut modules:

* kiwi-dracut-lib
* kiwi-dracut-live
* kiwi-dracut-oem-dump
* kiwi-dracut-oem-repart
* kiwi-dracut-overlay