### PR TITLE
Update list of main package requirements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,10 @@ Architecture: any
 Depends: ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
-         ${sphinxdoc:Depends}
+         ${sphinxdoc:Depends},
+         debootstrap,
+         tar,
+         screen
 Description: Flexible OS Image and Appliance Builder
  The KIWI Image System provides an operating system image builder
  for Linux supported hardware platforms as well as for virtualization

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          ${sphinxdoc:Depends},
          debootstrap,
-         tar,
+         tar (>= 1.2.7),
          screen
 Description: Flexible OS Image and Appliance Builder
  The KIWI Image System provides an operating system image builder
@@ -103,12 +103,10 @@ Description: KIWI - Dracut module for VMX (+overlay) image type
 
 Package: kiwi-systemdeps-core
 Architecture: any
-Depends: debootstrap,
-         gnupg,
+Depends: gnupg,
          mtools,
          openssl,
          rsync,
-         tar (>= 1.2.7),
          ${misc:Depends}
 Description: KIWI - Core host system dependencies
  This meta-package installs the necessary system dependencies

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,6 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          ${sphinxdoc:Depends},
          debootstrap,
-         tar (>= 1.2.7),
          screen
 Description: Flexible OS Image and Appliance Builder
  The KIWI Image System provides an operating system image builder


### PR DESCRIPTION
Added the following to the list of requirements:

* **debootstrap**
  This makes sense as a hard requirement for the debian kiwi
  package because for building new root tree's debootstrap is
  used by kiwi. As debootstrap is not a core component it cannot
  be guaranteed to exist on the system, thus require it

* **tar**
  The most simple image kiwi can build is a tarball from the
  root tree (tbz). I added tar to make sure this tool exists
  on the system

* **screen**
  This is a requirement from one of the latest PRs in kiwi:
  https://github.com/OSInside/kiwi/pull/1934
  In debug mode scripts are called through screen such that
  you can attach/detach and work from a real terminal environment

